### PR TITLE
Fixed bug of not handling None arguments in Quantization

### DIFF
--- a/evaluator.py
+++ b/evaluator.py
@@ -318,10 +318,17 @@ class QuantizedEvaluator():
 
         self.policy_model_path = policy_model_path
         self.quantized_model_path = quantized_model_path
-
-        self.quantized_model_args = quantized_model_args
-        self.policy_model_args = policy_model_args
-
+        
+        if quantized_model_args is None:
+            self.quantized_model_args = {}
+        else:
+            self.quantized_model_args = quantized_model_args
+            
+        if policy_model_args is None:
+            self.policy_model_args = {}
+        else:
+            self.policy_model_args = policy_model_args
+            
         self.quantized_dpo_evaluator = DPOModelEvaluator(
             task_type=task_type,
             policy_model_path=quantized_model_path,


### PR DESCRIPTION
In the `QuantizedEvaluator` class we also need to check if the arguments are None. See [Ed discussion](https://edstem.org/eu/courses/1159/discussion/117150) 